### PR TITLE
Refactored to only Usage/Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drupal Best Practices
+# Drupal Devops
 
 [![Build Status](https://travis-ci.org/ankitjain28may/drupal-best-practices.svg?branch=master)](https://travis-ci.org/ankitjain28may/drupal-best-practices)
 
@@ -14,11 +14,27 @@ You should have python2.7 installed on your server so that Ansible can use its m
 
   Let's see how to use and implement this project kit.
 
-### Configure .env file
+### Step 1 - Clone or Download the current repo
 
-You need to create `.env` file for each deploying server. It will also be managed by ansible automatically. You need to create `.env.<hostname>` file and add `<hostname>` name in `env_file` variable in host group_var file.
+```shell
+git clone https://github.com/dbjpanda/drupal-devops.git <project_name>
+```
 
-`cp .env.example .env.<hostname>`
+### Step 2 - Configure env file
+
+**For Server :**
+
+  You need to create `.env` file for each deploying server. It will also be managed by ansible automatically. You need to create `.env.<hostname>` file and add `<hostname>` name in `env_file` variable in host group_var file.
+
+  `cp .env.example .env.<hostname>`
+
+**For Local :**
+
+  Copy .env.example file to .env
+  ```shell
+    cp .env.example .env
+  ```
+>Example -
 
 ```
   APP_ENV=
@@ -37,221 +53,65 @@ You need to create `.env` file for each deploying server. It will also be manage
   EXPORT_DB_DUMP_ON_COMMIT=true
 ```
 
-**Note** : For configuring on Local system, create .env file and set configs.
+### Step 3 - Configure Ansible inventories and playbooks
 
-Copy .env.example file to .env
-```shell
-  cp .env.example .env
-```
+**For Server :**
 
-## Ansible
+  1. Add hosts name in Ansible Inventory under `ansible/inventories`.
 
-Ansible is the most powerful automation tool that can automate cloud provisioning, configuration management, application deployment, and many other IT needs.
-
-### Manage your Inventory
-
-Ansible represents what machines it manages using a very simple INI file that puts all of your managed machines in groups of your own choosing.
-
-It looks like this -
-
-```
-  [digitalocean]
-  example.com ansible_user=root
-
-  [aws]
-  example.me ansible_user=ubuntu
-```
-Once inventory hosts are listed under `ansible/inventories`, variables can be assigned to them in yml files (in a subdirectory called `group_vars`)
-
-It looks like this -
-
-```yml
-
-  remote_user: ubuntu
-  docker_group: docker
-  github_repo: 'https://github.com/ankitjain28may/drupal-best-practices.git'
-  staging_branch: 'develop'
-  env_file: 'ansible'
-  backup_dir: '/var/www'
-  project_dir: '/var/www'
-  project_folder_name: 'html'
-  backup_folder_name: 'backup'
-
-```
-
-**Note** : Configure default path to your inventory in `ansible.cfg` in root directory
-
-### Ansible Playbooks
-
-Anisble Playbooks can be used to manage configurations of and deployments to remote machines.
-
-Ansible playbooks looks like -
-
-```yml
-
-  ---
-  - name: Name of the playbook
-  hosts: <hostname>
-  roles:
-  - role1
-  - role2
-```
-Add your hosts name in existing playbooks defined in `drupal.*.yml` under `ansible` dir or create your own custom playbooks.
-
-### Playbooks
-
-In this project, Total 8 playbooks are defined to help you, Detailed description of these playbooks-
-
-1. **drupal.development.yml** is configured for your development environment -
+  2. Once inventory hosts are listed, variables can be assigned to them in yml files (in a subdirectory called `group_vars`).
 
   ```shell
-    ansible-playbook ansible/drupal.development.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{git-pull, env, restart, composer, drupal}`
-
-2. **drupal.docker-install.yml** is configured to install docker and docker-compose -
-
-  ```shell
-    ansible-playbook ansible/drupal.docker-install.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{docker-install}`
-
-3. **drupal.production.yml** is configured to setup site on production server -
-
-  ```shell
-    ansible-playbook ansible/drupal.production.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{backup, docker-install, git-clone, git-hooks, env, docker-build, composer-prod, drupal}`
-
-4. **drupal.restore-backup.yml** is configured to restore backup on your server -
-
-  ```shell
-    ansible-playbook ansible/drupal.restore-backup.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{restore, docker-build, composer-prod, drupal}`
-
-5. **drupal.staging.yml** is configured to setup site on staging server -
-
-  ```shell
-    ansible-playbook ansible/drupal.staging.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{backup, docker-install, git-stage, git-hooks, env, restart, composer, drupal}`
-
-6. **drupal.backup.yml** is configured to backup your site on server -
-
-  ```shell
-    ansible-playbook ansible/drupal.backup.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{backup}`
-
-7. **drupal.local.yml** is configured to configure development environment on your local system -
-
-  ```shell
-    ansible-playbook ansible/drupal.local.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{docker-install, git-hooks, docker-build, composer, drupal}`
-
-8. **drupal.travis.prod.yml** is configured to integrate Continuous Integration and Continuous Deployment -
-
-  ```shell
-    ansible-playbook ansible/drupal.travis.prod.yml -i <inventory_path>
-  ```
-  have following roles -
-  `{docker-build, composer, drupal}`
-
-### Roles
-
-1. **backup** - It will rename `html` folder to `backup` folder and create empty `html` folder.
-
-2. **composer** - Install Composer Dependencies with dev dependencies.
-
-3. **composer-prod** - Install Composer Dependencies without dev dependencies.
-
-4. **docker-build** - Delete previous container and rebuild image if there is any change and re-create `drupal` and `drupaldb` containers.
-
-5. **docker-install** - Install Docker and docker-compose on the server.
-
-6. **drupal** - Import Configuration and Rebuild Cache.
-
-7. **env** - Move `.env.example` to `.env`.
-
-8. **git-clone** - Clone the git repo.
-
-9. **git-pull** - Pull the changes from the git repo after stashing any local changes.
-
-10. **git-stage** - Clone the selective branch from git repo.
-
-11. **git-hooks** - Configure git hooks on pre-commit
-
-12. **restart** - Restart Docker containers.
-
-13. **restore** - Restore previously generated `backup` folder to `html` and `html` to `backup`.
-
-## Docker
-
-Docker is a tool designed to make it easier to create, deploy, and run applications by using containers. Containers allow a developer to package up an application with all of the parts it needs, such as libraries and other dependencies, and ship it all out as one package
-
-> This project will have two images from which we create two containers.
-
-1. [mariadb](https://hub.docker.com/_/mariadb/) image from [Docker hub](https://hub.docker.com) for creating database container.
-
-2. [ankitjain28/php-nginx-composer](https://hub.docker.com/r/ankitjain28/php-nginx-composer/) install nginx, php7.2 with its extensions and composer. This image is maintained by me under Github Repo [php-nginx-composer](https://github.com/ankitjain28may/php-nginx-composer)
-
-### Docker Compose
-
-Compose is a tool for defining and running multi-container Docker applications.
-
-We have defined `docker-compose.yml` file to create Containers from `ankitjain28/php-nginx-composer` and `mariadb` images.
-
-**docker-compose.yml** contains two services -
-
-1. **drupaldb** : It will create container name `drupaldb` using `mariadb` image and import the dump in the `db-dump` to the database. Set env variable in `.env` file.
-
-2. **drupal** : It will create container name `drupal` using `ankitjain28/php-nginx-composer` image and mount `/var/www/html` directory to `/var/www/html` in container and application runs on port `80`.
-
-It depends on **drupaldb** container for database.
-
-  ```
-    docker-compose up -d
-  ```
- will create two containers and you can anytime start and stop your container using-
-
-  ```
-    docker-compose stop <container-name>
+    cp example.yml <hostname>.yml
   ```
 
+  3. Add hosts in existing ansible playbooks, or you can create your custom playbooks and roles.
+
+**For Local :**
+
+  1. Hosts is already added in develop file under inventories with name `local`
+
   ```
-    docker-compose start <container-name>
+    [local]
+    localhost
+  ```
+  2. Config env vars in `local.yml` file in a subdirectory called `group_vars`
+
+  ```
+    backup_dir: '/var/www/backup'
+    project_dir: '/var/www/html'
+    project_folder_name: 'drupal'
+    backup_folder_name: 'drupal-backup'
   ```
 
-**Note** : You can configure your docker-compose file, Read more about it under [docker directory](https://github.com/ankitjain28may/drupal-best-practices/tree/master/docker)
+### Step 4 - Deployment
 
-## One Click deployment
+  Run ansible-playbooks with the path to the inventory file.
+
+**For Server :**
+
+  Various playbooks are defined in this project, you can deploy as per your requirements.
 
   ```shell
     ansible-playbook ansible/drupal.production.yml -i ansible/inventories/develop
   ```
-
   will deploy your drupal site on all the hosts from the inventory file.
 
-> Default inventory file is loaded from `ansible.cfg`.
+**For Local :**
 
-## Install Drupal on Localhost (Locally)
-
-1. Set group_vars for the localhost host in `localhost.yml` file in `ansible/group_vars` directory.
-
-2. Run this command -
+  Run `drupal.local.yml` playbook
 
   ```shell
     ansible-playbook ansible/drupal.local.yml --connection=local --extra-vars "ansible_sudo_pass=<local-system-password>"
   ```
+
+**Note** : Read more about Ansible playbooks in [Ansible dir](https://github.com/ankitjain28may/drupal-best-practices/tree/master/ansible)
+
+**Note** : Default inventory file is loaded from `ansible.cfg`.
+
+> All the services like php, nginx and mysql are automatically managed by Docker through docker-compose.
+
+**Note** : Read more about Docker and docker-compose in - [Docker dir](https://github.com/ankitjain28may/drupal-best-practices/tree/master/docker)
 
 > All the dependencies are managed using Composer.
 
@@ -281,7 +141,7 @@ Password Key should be - `ssh_pass`
 
 It will automatically deploy the changes to your deploying server.
 
-**Note** : Travis configuration will be set in `.env.travis` and `travis.yml` under group_vars dir and You can add your own custom roles under `roles` and called them from `drupal.travis.prod.yml` playbook for travis configuration.
+**Note** : Travis configuration will be set in `.env.travis`, `travis`, `travis.yml` and `drupal.travis.prod.yml`. You can add your own custom roles under `roles` and called them from `drupal.travis.prod.yml` playbook for travis configuration.
 
 ## Future Implementation
 


### PR DESCRIPTION
@dbjpanda,
#15 removed Ansible/Docker user info and redirected to respective directories. New README contains only installation/config instructions to jumpstart development/local env setup.